### PR TITLE
add 'sensor_msgs' dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
-  <!-- <depend>sensor_msgs</depned> -->
+  <depend>sensor_msgs</depend>
   <depend>segway_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
The package `sensor_msgs` is required here:
https://github.com/mul-cps/segwayrmp/blob/bf0776280814dd0c96177ea0635c5d15cc777840/CMakeLists.txt#L26